### PR TITLE
fixup: weather-gateway.yaml 中VirtualService 和 DestinationRule 修改成同一个namespace

### DIFF
--- a/install/weather-gateway.yaml
+++ b/install/weather-gateway.yaml
@@ -18,6 +18,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: frontend-dr
+  namespace: weather
 spec:
   host: frontend
   subsets:


### PR DESCRIPTION
fixup: weather-gateway.yaml 中VirtualService 和 DestinationRule 修改成同一个namespace